### PR TITLE
Improvements in BaseViewModel architecture

### DIFF
--- a/domain/lib/src/base/failure.dart
+++ b/domain/lib/src/base/failure.dart
@@ -4,6 +4,8 @@ abstract class Failure {
   Failure(this.errorMessage);
 }
 
+//TODO: Make this use @freezed annotation when there's more clarity on how to use it
+// see https://github.com/rrousselGit/freezed/issues/141
 class NetworkFailure implements Failure {
   final String _errorMessage;
   final Error cause;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -17,7 +17,7 @@ class HomeScreen extends StatelessWidget {
           padding: EdgeInsets.all(16.0),
           children: <Widget>[
             StreamBuilder<SummaryState>(
-              stream: _summaryViewModel.uiState,
+              stream: _summaryViewModel.uiState.distinct(), //TODO: the distinct should move to ViewModel implementation
               builder: (context, snapshot) {
                 return !snapshot.hasData ? CircularProgressIndicator() :
                  SummaryRow(
@@ -35,7 +35,7 @@ class HomeScreen extends StatelessWidget {
               height: 32.0,
             ),
             StreamBuilder<StateLevelState>(
-              stream: _mapStateLevelViewModel.uiState,
+              stream: _mapStateLevelViewModel.uiState.distinct(), //TODO: the distinct should move to ViewModel implementation
               builder: (context, snapshot) {
                 return !snapshot.hasData ? CircularProgressIndicator() : Container(
                     height: kMapSvgHeight * 1.1,

--- a/presentation/lib/src/base_view_model.dart
+++ b/presentation/lib/src/base_view_model.dart
@@ -3,16 +3,44 @@ import 'package:rxdart/rxdart.dart';
 
 abstract class BaseViewModel<S, A> {
   @protected S currentState;
-  final BehaviorSubject<S> uiState;
+  BehaviorSubject<S> uiState; //TODO: This needs to be final but we cannot use non-static methods in constructor. Find idiomatic Dart way to achieve this
+
+  final BehaviorSubject<A> _actions = BehaviorSubject<A>(); //TODO: can we make this a simple Stream instead of BehaviourSubject?
+
+  @protected Function(A) actionProcessor;
   
   BaseViewModel({@required S initialState}): 
-        this.currentState = initialState,
-        uiState = BehaviorSubject.seeded(initialState);
-
-  @protected void emit(S state) {
-    currentState = state;
-    uiState.sink.add(state);
+        this.currentState = initialState {
+    uiState = BehaviorSubject.seeded(
+        initialState,
+        onListen: onInit,
+        onCancel: onDispose);
+    _actions.listen((event) {
+      actionProcessor(event);
+    });
   }
 
-  void dispatchAction(A action);
+  @protected void emit(S state) {
+    //TODO: Use streams here instead so that we can use debounce, distinct etc
+    final distinct = currentState != state;
+    currentState = state;
+    if(distinct && !uiState.isClosed) uiState.sink.add(state);
+  }
+
+  void dispatchAction(A action) {
+    if(!_actions.isClosed) {
+      _actions.sink.add(action);
+    }
+  }
+
+  @mustCallSuper
+  void onInit() {
+    print('BaseViewModel onInit()');
+  }
+
+  @mustCallSuper
+  void onDispose() {
+    print('BaseViewModel onDispose()');
+    _actions.close();
+  }
 }

--- a/presentation/lib/src/map_state_level_view_model.dart
+++ b/presentation/lib/src/map_state_level_view_model.dart
@@ -25,12 +25,11 @@ class MapStateLevelViewModel
   MapStateLevelViewModel({
     @required StateLevelState initialState,
     @required this.getStateLevelUseCase
-  }) : super(initialState: initialState) {
-    dispatchAction(StateLevelAction.init());
-  }
+  }) : super(initialState: initialState);
 
   @override
-  void dispatchAction(StateLevelAction action) {
+  // TODO: implement actionProcessor
+  Function(StateLevelAction action) get actionProcessor => (action) {
     var stateLevelInfoSuccess = (Map<StateUT, SummaryInfo> success) =>
         emit(_mapToUiState(success));
     var stateLevelInfoFailure = (Failure failure) =>
@@ -49,6 +48,12 @@ class MapStateLevelViewModel
               category, stateLevelInfoSuccess, stateLevelInfoFailure);
         }
     );
+  };
+
+  @override
+  void onInit() {
+    super.onInit();
+    dispatchAction(StateLevelAction.init());
   }
 
   StateLevelState _mapToUiState(Map<StateUT, SummaryInfo> success) {

--- a/presentation/lib/src/summary_view_model.dart
+++ b/presentation/lib/src/summary_view_model.dart
@@ -32,20 +32,24 @@ class SummaryViewModel extends BaseViewModel<SummaryState, SummaryAction> {
 
   SummaryViewModel(
       {@required SummaryState initialState, @required this.getSummaryUseCase})
-      : super(initialState: initialState) {
+      : super(initialState: initialState);
+
+  @override
+  void onInit() {
+    super.onInit();
     dispatchAction(SummaryAction.init());
   }
 
   @override
-  void dispatchAction(SummaryAction action) {
-    action.when(
-        categoryTapped: (category) => emit(this.currentState.copyWith(selectedCategory: category)),
-        init: () => getSummaryUseCase.invoke(
-            Empty(),
-            (Map<Category, SummaryInfo> success) =>
-                emit(_mapToUiState(success)),
-            (Failure failure) => emit(_getErrorState())));
-  }
+  Function(SummaryAction action) get actionProcessor => (action){
+      action.when(
+          categoryTapped: (category) => emit(this.currentState.copyWith(selectedCategory: category)),
+          init: () => getSummaryUseCase.invoke(
+              Empty(),
+                  (Map<Category, SummaryInfo> success) =>
+                  emit(_mapToUiState(success)),
+                  (Failure failure) => emit(_getErrorState())));
+    };
 
   SummaryState _mapToUiState(Map<Category, SummaryInfo> success) {
     return this.currentState.copyWith(summaryItems: _mapToSummaryItemState(success));


### PR DESCRIPTION
- Provide an `onInit` hook for ViewModels (this can be used to dispatch init actions for example). It is called when at least one listener is active for the `uiState` stream
- Provide an `onDispose` hook which is called when all subscribers have unsubscribed
- `dispatchAction()` is not meant to be overridden anymore. Instead, override `actionProcessor`.
- Don't emit state if it has not changed

Closes #28 and #30 