### PR TITLE
Region selection bugfix, vertical viewpager

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,6 +57,7 @@ class _ModuleContainer {
         getStateLevelUseCase: injector.get<GetStateLevelUseCase>(),
         initialState: StateLevelState(
             selectedCategory: Category.confirmed,
+            highlightedRegion: null,
             stateLevelInfo: _emptyStateLevelDetails)));
 
     injector.map<ChartsViewModel>(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -44,66 +44,66 @@ class HomeScreen extends StatelessWidget {
                         },
                       );
               }),
-          SizedBox(
-            height: 32.0,
-          ),
           Expanded(
-            child: PageView(
-              scrollDirection: Axis.vertical,
-              controller: _pageController,
-              children: <Widget>[
-                StreamBuilder<StateLevelState>(
-                    stream: _mapStateLevelViewModel.uiState.distinct(),
-                    builder: (context, snapshot) {
-                      return !snapshot.hasData
-                          ? CircularProgressIndicator()
-                          : Container(
-                              height: MediaQuery.of(context).size.width *
-                                  0.9 *
-                                  kMapSvgHeight /
-                                  kMapSvgWidth,
-                              width: MediaQuery.of(context).size.width * 0.9,
-                              child: ZoomableWidget(
-                                child: MapWidget(
-                                  category: snapshot.data.selectedCategory,
-                                  statistics: snapshot.data.stateLevelInfo,
-                                  highlightedRegion:
-                                      snapshot.data.highlightedRegion,
-                                  onRegionHighlighted: (region) {
-                                    _mapStateLevelViewModel.dispatchAction(
-                                        StateLevelAction.highlightRegion(
-                                            region));
-                                  },
-                                ),
-                              ));
-                    }),
-                StreamBuilder<ChartsState>(
-                    stream: _chartViewModel.uiState.distinct(),
-                    builder: (context, snapshot) {
-                      return !snapshot.hasData
-                          ? CircularProgressIndicator()
-                          : AnimatedContainer(
-                              duration: kAnimationDurationMedium,
-                              decoration: BoxDecoration(
-                                  color: categoryColorsMap[
-                                          snapshot.data.currentCategory]
-                                      .withAlpha(16),
-                                  borderRadius: BorderRadius.circular(4.0)),
-                              child: Container(
-                                  height: 160.0,
-                                  width: 320.0,
-                                  padding: EdgeInsets.all(8.0),
-                                  child: PointsLineChart(
-                                    chartPoints: snapshot.data.dataPoints
-                                        .map((HistoricalDataPoint p) =>
-                                            ChartPoint(
-                                                date: p.date, count: p.count))
-                                        .toList(),
-                                    category: snapshot.data.currentCategory,
-                                  )),
-                            );
-                    })
-              ],
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: PageView(
+                scrollDirection: Axis.vertical,
+                controller: _pageController,
+                children: <Widget>[
+                  StreamBuilder<StateLevelState>(
+                      stream: _mapStateLevelViewModel.uiState.distinct(),
+                      builder: (context, snapshot) {
+                        return !snapshot.hasData
+                            ? CircularProgressIndicator()
+                            : Container(
+                                height: MediaQuery.of(context).size.width *
+                                    0.9 *
+                                    kMapSvgHeight /
+                                    kMapSvgWidth,
+                                width: MediaQuery.of(context).size.width * 0.9,
+                                child: ZoomableWidget(
+                                  child: MapWidget(
+                                    category: snapshot.data.selectedCategory,
+                                    statistics: snapshot.data.stateLevelInfo,
+                                    highlightedRegion:
+                                        snapshot.data.highlightedRegion,
+                                    onRegionHighlighted: (region) {
+                                      _mapStateLevelViewModel.dispatchAction(
+                                          StateLevelAction.highlightRegion(
+                                              region));
+                                    },
+                                  ),
+                                ));
+                      }),
+                  StreamBuilder<ChartsState>(
+                      stream: _chartViewModel.uiState.distinct(),
+                      builder: (context, snapshot) {
+                        return !snapshot.hasData
+                            ? CircularProgressIndicator()
+                            : AnimatedContainer(
+                                duration: kAnimationDurationMedium,
+                                decoration: BoxDecoration(
+                                    color: categoryColorsMap[
+                                            snapshot.data.currentCategory]
+                                        .withAlpha(16),
+                                    borderRadius: BorderRadius.circular(4.0)),
+                                child: Container(
+                                    height: 160.0,
+                                    width: 320.0,
+                                    padding: EdgeInsets.all(8.0),
+                                    child: PointsLineChart(
+                                      chartPoints: snapshot.data.dataPoints
+                                          .map((HistoricalDataPoint p) =>
+                                              ChartPoint(
+                                                  date: p.date, count: p.count))
+                                          .toList(),
+                                      category: snapshot.data.currentCategory,
+                                    )),
+                              );
+                      })
+                ],
+              ),
             ),
           ),
         ],

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -16,74 +16,98 @@ class HomeScreen extends StatelessWidget {
   final _chartViewModel = Injector.getInjector()
       .get<ChartsViewModel>(); //TODO: Inject this in constructor
 
+  final PageController _pageController = PageController(viewportFraction: 0.85);
+
   @override
   Widget build(BuildContext context) {
-    return ListView(
-      padding: EdgeInsets.all(16.0),
-      children: <Widget>[
-        StreamBuilder<SummaryState>(
-            stream: _summaryViewModel.uiState.distinct(),
-            //TODO: the distinct should move to ViewModel implementation
-            builder: (context, snapshot) {
-              return !snapshot.hasData
-                  ? CircularProgressIndicator()
-                  : SummaryRow(
-                      selectedCategory: snapshot.data.selectedCategory,
-                      summaryInfo: snapshot.data.summaryItems,
-                      onCategorySelected: (Category category) {
-                        //TODO: Combine these into one ViewModel
-                        _summaryViewModel.dispatchAction(
-                            SummaryAction.categoryTapped(category));
-                        _mapStateLevelViewModel.dispatchAction(
-                            StateLevelAction.selectCategory(category));
-                        _chartViewModel.dispatchAction(ChartsAction.selectCategory(category));
-                      },
-                    );
-            }),
-        SizedBox(
-          height: 32.0,
-        ),
-        StreamBuilder<StateLevelState>(
-            stream: _mapStateLevelViewModel.uiState.distinct(),
-            //TODO: the distinct should move to ViewModel implementation
-            builder: (context, snapshot) {
-              return !snapshot.hasData
-                  ? CircularProgressIndicator()
-                  : Container(
-                      height: kMapSvgHeight * 1.1,
-                      width: kMapSvgWidth * 1.1,
-                      child: ZoomableWidget(
-                        child: MapWidget(
-                          category: snapshot.data.selectedCategory,
-                          statistics: snapshot.data.stateLevelInfo,
-                        ),
-                      ));
-            }),
-        SizedBox(height: 32.0,),
-        StreamBuilder<ChartsState>(
-            stream: _chartViewModel.uiState.distinct(),
-            builder: (context, snapshot) {
-              return !snapshot.hasData
-                  ? CircularProgressIndicator()
-                  : AnimatedContainer(
-                duration: kAnimationDurationMedium,
-                      decoration: BoxDecoration(
-                          color: categoryColorsMap[snapshot.data.currentCategory].withAlpha(16),
-                          borderRadius: BorderRadius.circular(4.0)),
-                      child: Container(
-                          height: 160.0,
-                          width: 320.0,
-                          padding: EdgeInsets.all(8.0),
-                          child: PointsLineChart(
-                            chartPoints: snapshot.data.dataPoints
-                                .map((HistoricalDataPoint p) =>
-                                    ChartPoint(date: p.date, count: p.count))
-                                .toList(),
-                            category: snapshot.data.currentCategory,
-                          )),
-                    );
-            })
-      ],
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: <Widget>[
+          StreamBuilder<SummaryState>(
+              stream: _summaryViewModel.uiState.distinct(),
+              //TODO: the distinct should move to ViewModel implementation
+              builder: (context, snapshot) {
+                return !snapshot.hasData
+                    ? CircularProgressIndicator()
+                    : SummaryRow(
+                        selectedCategory: snapshot.data.selectedCategory,
+                        summaryInfo: snapshot.data.summaryItems,
+                        onCategorySelected: (Category category) {
+                          //TODO: Combine these into one ViewModel
+                          _summaryViewModel.dispatchAction(
+                              SummaryAction.categoryTapped(category));
+                          _mapStateLevelViewModel.dispatchAction(
+                              StateLevelAction.selectCategory(category));
+                          _chartViewModel.dispatchAction(
+                              ChartsAction.selectCategory(category));
+                        },
+                      );
+              }),
+          SizedBox(
+            height: 32.0,
+          ),
+          Expanded(
+            child: PageView(
+              scrollDirection: Axis.vertical,
+              controller: _pageController,
+              children: <Widget>[
+                StreamBuilder<StateLevelState>(
+                    stream: _mapStateLevelViewModel.uiState.distinct(),
+                    builder: (context, snapshot) {
+                      return !snapshot.hasData
+                          ? CircularProgressIndicator()
+                          : Container(
+                              height: MediaQuery.of(context).size.width *
+                                  0.9 *
+                                  kMapSvgHeight /
+                                  kMapSvgWidth,
+                              width: MediaQuery.of(context).size.width * 0.9,
+                              child: ZoomableWidget(
+                                child: MapWidget(
+                                  category: snapshot.data.selectedCategory,
+                                  statistics: snapshot.data.stateLevelInfo,
+                                  highlightedRegion:
+                                      snapshot.data.highlightedRegion,
+                                  onRegionHighlighted: (region) {
+                                    _mapStateLevelViewModel.dispatchAction(
+                                        StateLevelAction.highlightRegion(
+                                            region));
+                                  },
+                                ),
+                              ));
+                    }),
+                StreamBuilder<ChartsState>(
+                    stream: _chartViewModel.uiState.distinct(),
+                    builder: (context, snapshot) {
+                      return !snapshot.hasData
+                          ? CircularProgressIndicator()
+                          : AnimatedContainer(
+                              duration: kAnimationDurationMedium,
+                              decoration: BoxDecoration(
+                                  color: categoryColorsMap[
+                                          snapshot.data.currentCategory]
+                                      .withAlpha(16),
+                                  borderRadius: BorderRadius.circular(4.0)),
+                              child: Container(
+                                  height: 160.0,
+                                  width: 320.0,
+                                  padding: EdgeInsets.all(8.0),
+                                  child: PointsLineChart(
+                                    chartPoints: snapshot.data.dataPoints
+                                        .map((HistoricalDataPoint p) =>
+                                            ChartPoint(
+                                                date: p.date, count: p.count))
+                                        .toList(),
+                                    category: snapshot.data.currentCategory,
+                                  )),
+                            );
+                    })
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/maps/map_widget.dart
+++ b/lib/widgets/maps/map_widget.dart
@@ -15,9 +15,11 @@ import 'map_svg_data.dart';
 class MapWidget extends StatefulWidget {
   final Map<StateUT, SummaryInfo> statistics;
   final Category category;
+  final StateUT highlightedRegion;
+  final Function onRegionHighlighted;
   final _maxCount;
 
-  MapWidget({Key key, this.statistics, this.category}): this._maxCount =_calculateMaxCount(statistics), super(key: key);
+  MapWidget({Key key, this.statistics, this.category, this.highlightedRegion, this.onRegionHighlighted}): this._maxCount =_calculateMaxCount(statistics), super(key: key);
 
   @override
   _MapWidgetState createState() => _MapWidgetState();
@@ -28,7 +30,7 @@ class MapWidget extends StatefulWidget {
 }
 
 class _MapWidgetState extends State<MapWidget> {
-  StateUT _pressedProvince;
+  //StateUT _pressedProvince;
 
   _MapWidgetState();
 
@@ -73,15 +75,13 @@ class _MapWidgetState extends State<MapWidget> {
                       curve: Curves.easeInOut,
                       color: _getColorForStatGradient(statistic.total, widget.category, widget._maxCount)
                   ))),
-          CustomPaint(painter: PathPainter(region, _pressedProvince == region, widget.category))
+          CustomPaint(painter: PathPainter(region, widget.highlightedRegion == region, widget.category))
         ]),
         clipper: PathClipper(region));
   }
 
   void _regionPressed(StateUT province) {
-    setState(() {
-      _pressedProvince = province;
-    });
+    widget.onRegionHighlighted(province);
   }
 }
 
@@ -101,7 +101,7 @@ class PathPainter extends CustomPainter {
         Paint()
           ..style = PaintingStyle.stroke
           ..color = _isPressed ? baseColor : baseColor.withAlpha(64)
-          ..strokeWidth = _isPressed ? 3.0 : 1.0);
+          ..strokeWidth = _isPressed ? 2.5 : 1.0);
   }
 
   @override

--- a/presentation/lib/src/map_state_level_view_model.dart
+++ b/presentation/lib/src/map_state_level_view_model.dart
@@ -7,47 +7,51 @@ part 'map_state_level_view_model.freezed.dart';
 
 @freezed
 abstract class StateLevelState with _$StateLevelState {
-  const factory StateLevelState({
-    @required Category selectedCategory,
-    @required Map<StateUT, SummaryInfo> stateLevelInfo}) = _StateLevelState;
+  const factory StateLevelState(
+      {@required Category selectedCategory,
+      StateUT highlightedRegion,
+      @required Map<StateUT, SummaryInfo> stateLevelInfo}) = _StateLevelState;
 }
 
 @freezed
 abstract class StateLevelAction with _$StateLevelAction {
   const factory StateLevelAction.init() = _StateLevelActionInit;
-  const factory StateLevelAction.selectCategory(Category category) = _SelectCategory;
+  const factory StateLevelAction.selectCategory(Category category) =
+      _SelectCategory;
+  const factory StateLevelAction.highlightRegion(StateUT region) =
+      _HighlightRegion;
 }
 
 class MapStateLevelViewModel
     extends BaseViewModel<StateLevelState, StateLevelAction> {
   final GetStateLevelUseCase getStateLevelUseCase;
 
-  MapStateLevelViewModel({
-    @required StateLevelState initialState,
-    @required this.getStateLevelUseCase
-  }) : super(initialState: initialState);
+  MapStateLevelViewModel(
+      {@required StateLevelState initialState,
+      @required this.getStateLevelUseCase})
+      : super(initialState: initialState);
 
   @override
   Function(StateLevelAction action) get actionProcessor => (action) {
-    var stateLevelInfoSuccess = (Map<StateUT, SummaryInfo> success) =>
-        emit(_mapToUiState(success));
-    var stateLevelInfoFailure = (Failure failure) =>
-        emit(_mapToUiStateFailure(failure));
+        var stateLevelInfoSuccess =
+            (Map<StateUT, SummaryInfo> success) => emit(_mapToUiState(success));
+        var stateLevelInfoFailure =
+            (Failure failure) => emit(_mapToUiStateFailure(failure));
 
-    action.when(
-        init: () =>
-            getStateLevelUseCase.invoke(
+        action.when(
+            init: () => getStateLevelUseCase.invoke(
                 currentState.selectedCategory,
                 stateLevelInfoSuccess,
-                stateLevelInfoFailure
-            ),
-        selectCategory: (category) {
-          emit(this.currentState.copyWith(selectedCategory: category));
-          getStateLevelUseCase.invoke(
-              category, stateLevelInfoSuccess, stateLevelInfoFailure);
-        }
-    );
-  };
+                stateLevelInfoFailure),
+            selectCategory: (category) {
+              emit(this.currentState.copyWith(
+                  selectedCategory: category, highlightedRegion: null));
+              getStateLevelUseCase.invoke(
+                  category, stateLevelInfoSuccess, stateLevelInfoFailure);
+            },
+            highlightRegion: (region) =>
+                emit(this.currentState.copyWith(highlightedRegion: region)));
+      };
 
   @override
   void onInit() {
@@ -60,7 +64,7 @@ class MapStateLevelViewModel
   }
 
   StateLevelState _mapToUiStateFailure(Failure failure) {
-    final empty = { for(var state in StateUT.values) state: SummaryInfo(0, 0)};
+    final empty = {for (var state in StateUT.values) state: SummaryInfo(0, 0)};
     return this.currentState.copyWith(stateLevelInfo: empty);
   }
 }

--- a/presentation/lib/src/map_state_level_view_model.freezed.dart
+++ b/presentation/lib/src/map_state_level_view_model.freezed.dart
@@ -14,9 +14,11 @@ class _$StateLevelStateTearOff {
 
   _StateLevelState call(
       {@required Category selectedCategory,
+      StateUT highlightedRegion,
       @required Map<StateUT, SummaryInfo> stateLevelInfo}) {
     return _StateLevelState(
       selectedCategory: selectedCategory,
+      highlightedRegion: highlightedRegion,
       stateLevelInfo: stateLevelInfo,
     );
   }
@@ -27,6 +29,7 @@ const $StateLevelState = _$StateLevelStateTearOff();
 
 mixin _$StateLevelState {
   Category get selectedCategory;
+  StateUT get highlightedRegion;
   Map<StateUT, SummaryInfo> get stateLevelInfo;
 
   $StateLevelStateCopyWith<StateLevelState> get copyWith;
@@ -37,7 +40,9 @@ abstract class $StateLevelStateCopyWith<$Res> {
           StateLevelState value, $Res Function(StateLevelState) then) =
       _$StateLevelStateCopyWithImpl<$Res>;
   $Res call(
-      {Category selectedCategory, Map<StateUT, SummaryInfo> stateLevelInfo});
+      {Category selectedCategory,
+      StateUT highlightedRegion,
+      Map<StateUT, SummaryInfo> stateLevelInfo});
 }
 
 class _$StateLevelStateCopyWithImpl<$Res>
@@ -51,12 +56,16 @@ class _$StateLevelStateCopyWithImpl<$Res>
   @override
   $Res call({
     Object selectedCategory = freezed,
+    Object highlightedRegion = freezed,
     Object stateLevelInfo = freezed,
   }) {
     return _then(_value.copyWith(
       selectedCategory: selectedCategory == freezed
           ? _value.selectedCategory
           : selectedCategory as Category,
+      highlightedRegion: highlightedRegion == freezed
+          ? _value.highlightedRegion
+          : highlightedRegion as StateUT,
       stateLevelInfo: stateLevelInfo == freezed
           ? _value.stateLevelInfo
           : stateLevelInfo as Map<StateUT, SummaryInfo>,
@@ -71,7 +80,9 @@ abstract class _$StateLevelStateCopyWith<$Res>
       __$StateLevelStateCopyWithImpl<$Res>;
   @override
   $Res call(
-      {Category selectedCategory, Map<StateUT, SummaryInfo> stateLevelInfo});
+      {Category selectedCategory,
+      StateUT highlightedRegion,
+      Map<StateUT, SummaryInfo> stateLevelInfo});
 }
 
 class __$StateLevelStateCopyWithImpl<$Res>
@@ -87,12 +98,16 @@ class __$StateLevelStateCopyWithImpl<$Res>
   @override
   $Res call({
     Object selectedCategory = freezed,
+    Object highlightedRegion = freezed,
     Object stateLevelInfo = freezed,
   }) {
     return _then(_StateLevelState(
       selectedCategory: selectedCategory == freezed
           ? _value.selectedCategory
           : selectedCategory as Category,
+      highlightedRegion: highlightedRegion == freezed
+          ? _value.highlightedRegion
+          : highlightedRegion as StateUT,
       stateLevelInfo: stateLevelInfo == freezed
           ? _value.stateLevelInfo
           : stateLevelInfo as Map<StateUT, SummaryInfo>,
@@ -104,18 +119,22 @@ class _$_StateLevelState
     with DiagnosticableTreeMixin
     implements _StateLevelState {
   const _$_StateLevelState(
-      {@required this.selectedCategory, @required this.stateLevelInfo})
+      {@required this.selectedCategory,
+      this.highlightedRegion,
+      @required this.stateLevelInfo})
       : assert(selectedCategory != null),
         assert(stateLevelInfo != null);
 
   @override
   final Category selectedCategory;
   @override
+  final StateUT highlightedRegion;
+  @override
   final Map<StateUT, SummaryInfo> stateLevelInfo;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'StateLevelState(selectedCategory: $selectedCategory, stateLevelInfo: $stateLevelInfo)';
+    return 'StateLevelState(selectedCategory: $selectedCategory, highlightedRegion: $highlightedRegion, stateLevelInfo: $stateLevelInfo)';
   }
 
   @override
@@ -124,6 +143,7 @@ class _$_StateLevelState
     properties
       ..add(DiagnosticsProperty('type', 'StateLevelState'))
       ..add(DiagnosticsProperty('selectedCategory', selectedCategory))
+      ..add(DiagnosticsProperty('highlightedRegion', highlightedRegion))
       ..add(DiagnosticsProperty('stateLevelInfo', stateLevelInfo));
   }
 
@@ -134,6 +154,9 @@ class _$_StateLevelState
             (identical(other.selectedCategory, selectedCategory) ||
                 const DeepCollectionEquality()
                     .equals(other.selectedCategory, selectedCategory)) &&
+            (identical(other.highlightedRegion, highlightedRegion) ||
+                const DeepCollectionEquality()
+                    .equals(other.highlightedRegion, highlightedRegion)) &&
             (identical(other.stateLevelInfo, stateLevelInfo) ||
                 const DeepCollectionEquality()
                     .equals(other.stateLevelInfo, stateLevelInfo)));
@@ -143,6 +166,7 @@ class _$_StateLevelState
   int get hashCode =>
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(selectedCategory) ^
+      const DeepCollectionEquality().hash(highlightedRegion) ^
       const DeepCollectionEquality().hash(stateLevelInfo);
 
   @override
@@ -153,10 +177,13 @@ class _$_StateLevelState
 abstract class _StateLevelState implements StateLevelState {
   const factory _StateLevelState(
       {@required Category selectedCategory,
+      StateUT highlightedRegion,
       @required Map<StateUT, SummaryInfo> stateLevelInfo}) = _$_StateLevelState;
 
   @override
   Category get selectedCategory;
+  @override
+  StateUT get highlightedRegion;
   @override
   Map<StateUT, SummaryInfo> get stateLevelInfo;
   @override
@@ -175,6 +202,12 @@ class _$StateLevelActionTearOff {
       category,
     );
   }
+
+  _HighlightRegion highlightRegion(StateUT region) {
+    return _HighlightRegion(
+      region,
+    );
+  }
 }
 
 // ignore: unused_element
@@ -185,22 +218,26 @@ mixin _$StateLevelAction {
   Result when<Result extends Object>({
     @required Result init(),
     @required Result selectCategory(Category category),
+    @required Result highlightRegion(StateUT region),
   });
   @optionalTypeArgs
   Result maybeWhen<Result extends Object>({
     Result init(),
     Result selectCategory(Category category),
+    Result highlightRegion(StateUT region),
     @required Result orElse(),
   });
   @optionalTypeArgs
   Result map<Result extends Object>({
     @required Result init(_StateLevelActionInit value),
     @required Result selectCategory(_SelectCategory value),
+    @required Result highlightRegion(_HighlightRegion value),
   });
   @optionalTypeArgs
   Result maybeMap<Result extends Object>({
     Result init(_StateLevelActionInit value),
     Result selectCategory(_SelectCategory value),
+    Result highlightRegion(_HighlightRegion value),
     @required Result orElse(),
   });
 }
@@ -266,9 +303,11 @@ class _$_StateLevelActionInit
   Result when<Result extends Object>({
     @required Result init(),
     @required Result selectCategory(Category category),
+    @required Result highlightRegion(StateUT region),
   }) {
     assert(init != null);
     assert(selectCategory != null);
+    assert(highlightRegion != null);
     return init();
   }
 
@@ -277,6 +316,7 @@ class _$_StateLevelActionInit
   Result maybeWhen<Result extends Object>({
     Result init(),
     Result selectCategory(Category category),
+    Result highlightRegion(StateUT region),
     @required Result orElse(),
   }) {
     assert(orElse != null);
@@ -291,9 +331,11 @@ class _$_StateLevelActionInit
   Result map<Result extends Object>({
     @required Result init(_StateLevelActionInit value),
     @required Result selectCategory(_SelectCategory value),
+    @required Result highlightRegion(_HighlightRegion value),
   }) {
     assert(init != null);
     assert(selectCategory != null);
+    assert(highlightRegion != null);
     return init(this);
   }
 
@@ -302,6 +344,7 @@ class _$_StateLevelActionInit
   Result maybeMap<Result extends Object>({
     Result init(_StateLevelActionInit value),
     Result selectCategory(_SelectCategory value),
+    Result highlightRegion(_HighlightRegion value),
     @required Result orElse(),
   }) {
     assert(orElse != null);
@@ -386,9 +429,11 @@ class _$_SelectCategory
   Result when<Result extends Object>({
     @required Result init(),
     @required Result selectCategory(Category category),
+    @required Result highlightRegion(StateUT region),
   }) {
     assert(init != null);
     assert(selectCategory != null);
+    assert(highlightRegion != null);
     return selectCategory(category);
   }
 
@@ -397,6 +442,7 @@ class _$_SelectCategory
   Result maybeWhen<Result extends Object>({
     Result init(),
     Result selectCategory(Category category),
+    Result highlightRegion(StateUT region),
     @required Result orElse(),
   }) {
     assert(orElse != null);
@@ -411,9 +457,11 @@ class _$_SelectCategory
   Result map<Result extends Object>({
     @required Result init(_StateLevelActionInit value),
     @required Result selectCategory(_SelectCategory value),
+    @required Result highlightRegion(_HighlightRegion value),
   }) {
     assert(init != null);
     assert(selectCategory != null);
+    assert(highlightRegion != null);
     return selectCategory(this);
   }
 
@@ -422,6 +470,7 @@ class _$_SelectCategory
   Result maybeMap<Result extends Object>({
     Result init(_StateLevelActionInit value),
     Result selectCategory(_SelectCategory value),
+    Result highlightRegion(_HighlightRegion value),
     @required Result orElse(),
   }) {
     assert(orElse != null);
@@ -437,4 +486,132 @@ abstract class _SelectCategory implements StateLevelAction {
 
   Category get category;
   _$SelectCategoryCopyWith<_SelectCategory> get copyWith;
+}
+
+abstract class _$HighlightRegionCopyWith<$Res> {
+  factory _$HighlightRegionCopyWith(
+          _HighlightRegion value, $Res Function(_HighlightRegion) then) =
+      __$HighlightRegionCopyWithImpl<$Res>;
+  $Res call({StateUT region});
+}
+
+class __$HighlightRegionCopyWithImpl<$Res>
+    extends _$StateLevelActionCopyWithImpl<$Res>
+    implements _$HighlightRegionCopyWith<$Res> {
+  __$HighlightRegionCopyWithImpl(
+      _HighlightRegion _value, $Res Function(_HighlightRegion) _then)
+      : super(_value, (v) => _then(v as _HighlightRegion));
+
+  @override
+  _HighlightRegion get _value => super._value as _HighlightRegion;
+
+  @override
+  $Res call({
+    Object region = freezed,
+  }) {
+    return _then(_HighlightRegion(
+      region == freezed ? _value.region : region as StateUT,
+    ));
+  }
+}
+
+class _$_HighlightRegion
+    with DiagnosticableTreeMixin
+    implements _HighlightRegion {
+  const _$_HighlightRegion(this.region) : assert(region != null);
+
+  @override
+  final StateUT region;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'StateLevelAction.highlightRegion(region: $region)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'StateLevelAction.highlightRegion'))
+      ..add(DiagnosticsProperty('region', region));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _HighlightRegion &&
+            (identical(other.region, region) ||
+                const DeepCollectionEquality().equals(other.region, region)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(region);
+
+  @override
+  _$HighlightRegionCopyWith<_HighlightRegion> get copyWith =>
+      __$HighlightRegionCopyWithImpl<_HighlightRegion>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  Result when<Result extends Object>({
+    @required Result init(),
+    @required Result selectCategory(Category category),
+    @required Result highlightRegion(StateUT region),
+  }) {
+    assert(init != null);
+    assert(selectCategory != null);
+    assert(highlightRegion != null);
+    return highlightRegion(region);
+  }
+
+  @override
+  @optionalTypeArgs
+  Result maybeWhen<Result extends Object>({
+    Result init(),
+    Result selectCategory(Category category),
+    Result highlightRegion(StateUT region),
+    @required Result orElse(),
+  }) {
+    assert(orElse != null);
+    if (highlightRegion != null) {
+      return highlightRegion(region);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  Result map<Result extends Object>({
+    @required Result init(_StateLevelActionInit value),
+    @required Result selectCategory(_SelectCategory value),
+    @required Result highlightRegion(_HighlightRegion value),
+  }) {
+    assert(init != null);
+    assert(selectCategory != null);
+    assert(highlightRegion != null);
+    return highlightRegion(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  Result maybeMap<Result extends Object>({
+    Result init(_StateLevelActionInit value),
+    Result selectCategory(_SelectCategory value),
+    Result highlightRegion(_HighlightRegion value),
+    @required Result orElse(),
+  }) {
+    assert(orElse != null);
+    if (highlightRegion != null) {
+      return highlightRegion(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _HighlightRegion implements StateLevelAction {
+  const factory _HighlightRegion(StateUT region) = _$_HighlightRegion;
+
+  StateUT get region;
+  _$HighlightRegionCopyWith<_HighlightRegion> get copyWith;
 }


### PR DESCRIPTION
1. If a state or UT has been selected, then clear this selection when moving to a different category (fixes #39 )
2. Retain the summary row always at the top of the screen, swipe between map and chart widgets (Closes #37 )